### PR TITLE
Update examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Console.WriteLine(expr.ToString("C#"));
 Console.WriteLine(expr.ToString("Visual Basic"));
 // prints: Function() True
 
-Console.WriteLine(expr.ToString("Factory methods"));
+Console.WriteLine(expr.ToString("Factory methods", "C#"));
 // prints:
 /*
     // using static System.Linq.Expressions.Expression
@@ -23,7 +23,7 @@ Console.WriteLine(expr.ToString("Factory methods"));
     )
 */
 
-Console.WriteLine(expr.ToString("Object notation"));
+Console.WriteLine(expr.ToString("Object notation", "C#"));
 // prints:
 /*
     new Expression<Func<bool>> {


### PR DESCRIPTION
Language or second parameter is needed for these two examples. Otherwise we get the following error. Using `C#` as the language ensures that the output matches the examples. 

```
Unhandled exception. System.ArgumentException: Invalid language
```